### PR TITLE
break: allow resume operation on `box folder:download`.

### DIFF
--- a/src/commands/folders/download.js
+++ b/src/commands/folders/download.js
@@ -52,8 +52,7 @@ class FoldersDownloadCommand extends BoxCommand {
         } else if (item.type === 'file') {
           spinner.text = `Downloading file ${item.id} to ${item.path}`;
 
-          const fileExists = await fs.access(path.join(destinationPath, item.path), fs.access.F_OK).then(() => true).catch(() => true);
-
+          const fileExists = await new Promise(resolve => fs.access(path.join(destinationPath, item.path), fs.access.F_OK, err => resolve(err ? false : true)));
           if (fileExists) {
             continue;
           }
@@ -69,7 +68,7 @@ class FoldersDownloadCommand extends BoxCommand {
             stream.pipe(output);
             /* eslint-disable promise/avoid-new */
             // We need to await the end of the stream to avoid a race condition here
-            return new Promise((resolve, reject) => {
+            await new Promise((resolve, reject) => {
               stream.on('end', resolve);
               stream.on('error', reject);
             });


### PR DESCRIPTION
If the folder already exists, continues. If the file already exists, skips it.

When downloading large directories, often the connection will break, the tool will hang, and the download needs to be restarted from the beginning. This change should help.

This PR also treats race conditions so that you can run multiple downloads in parallel.